### PR TITLE
Corrected pin string construction from JPasswordField contents

### DIFF
--- a/cie-java/src/it/ipzs/cieid/MainFrame.java
+++ b/cie-java/src/it/ipzs/cieid/MainFrame.java
@@ -3617,7 +3617,7 @@ public class MainFrame extends JFrame {
         int i;
         for (i = 0; i < passwordFields.length; i++) {
             JPasswordField field = passwordFields[i];
-            pin += field.getPassword();
+            pin += String.valueOf(field.getPassword());
         }
 
         if (pin.length() != 8) {


### PR DESCRIPTION
In the initial loop on the various `JPasswordField` in [MainFrame.abbinaCie()](https://github.com/M0Rf30/cie-middleware-linux/blob/4adfcea43df6b4c6ca45125a1412d0a5e7ce8663/cie-java/src/it/ipzs/cieid/MainFrame.java#L3614), `getPassword()` do not return the 1 character string content of the field, but a `char[]`. Adding it to the in-construction `pin` string implicitly calls `toString[]` on the `char[]`, which results in a textual representation of it, something like this: `[C@27716f4`. 
Here we propose passing the `String.valueOf()` of the `char[]` to the in-construction `pin` string.  