### PR TITLE
fix: configure logger instance only once

### DIFF
--- a/libs/pkcs11/src/LOGGER/Logger.cpp
+++ b/libs/pkcs11/src/LOGGER/Logger.cpp
@@ -101,17 +101,17 @@ Logger::~Logger() {
 Logger* Logger::getInstance() throw() {
   if (m_Instance == 0) {
     m_Instance = new Logger();
-  }
 
-  int log_level = m_Instance->getLogConfig();
-  printf("Lib log level: %d\n", log_level);
-
-  if (log_level == LOG_STATUS_DISABLED) {
-    m_Instance->disableLog();
-  } else if (log_level > 0 && log_level < 3) {
-    m_Instance->enableFileLogging();
-    m_Instance->enableLog();
-    m_Instance->updateLogLevel(static_cast<LogLevel>(log_level));
+    int log_level = m_Instance->getLogConfig();
+    printf("Lib log level: %d\n", log_level);
+  
+    if (log_level == LOG_STATUS_DISABLED) {
+      m_Instance->disableLog();
+    } else if (log_level > 0 && log_level < 3) {
+      m_Instance->enableFileLogging();
+      m_Instance->enableLog();
+      m_Instance->updateLogLevel(static_cast<LogLevel>(log_level));
+    }
   }
 
   return m_Instance;


### PR DESCRIPTION
By now the logger instance is configured on every `LOG_XXXX` macro invocation, thus the message `Lib log level: X` is printed to stdout quite often.